### PR TITLE
Add service worker scope to OneSignal

### DIFF
--- a/pages/hooks/onesignal.tsx
+++ b/pages/hooks/onesignal.tsx
@@ -18,6 +18,7 @@ const useOneSignal = () => {
               enable: true,
               size: "large",
             },
+            serviceWorkerParam: { scope: "/onesignal" },
           })
 
           OneSignal.addListenerForNotificationOpened((notification) =>


### PR DESCRIPTION
This prevents conflicts with the root service worker.

NOTE: I have not tested this change.

This OneSignal Service Worker config is documented in these links:
* https://documentation.onesignal.com/docs/onesignal-service-worker-faq#customizing-your-service-worker-integration
* https://github.com/OneSignal/OneSignal-Website-SDK/blob/160000.beta2/MIGRATION_GUIDE.md#4-custom-setup-changes